### PR TITLE
pip3 instead of pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Installation
 You will need both the pep8 and pyflakes modules, available from pypi.
 
 ```
-  pip install pyflakes
-  pip install pep8
+  pip3 install pyflakes
+  pip3 install pep8
 ```
 
 Copy (or clone) this repository in your gedit plugins directory (create it if it


### PR DESCRIPTION
I needed the python3 version of the modules for the plugin to work.