### PR TITLE
Remove calls to add_helper()

### DIFF
--- a/checkpython/checkpython.py
+++ b/checkpython/checkpython.py
@@ -32,9 +32,6 @@ class CheckpythonWindowActivatable(GObject.Object, Gedit.WindowActivatable):
         action.connect('activate', self.check_all)
         self.window.add_action(action)
 
-        for view in self.window.get_views():
-            self.add_helper(view, self.window)
-
         self._init_error_list()
 
     def _init_error_list(self):


### PR DESCRIPTION
The CheckpythonWindowActivatable class does not implement
a add_helper() method.

This makes the plugin run on GEdit 3.18